### PR TITLE
vg-get-the-project-path documentation uses imperative

### DIFF
--- a/show-notes/1-finding-files-recursively-using-locate.md
+++ b/show-notes/1-finding-files-recursively-using-locate.md
@@ -32,8 +32,8 @@ Next we will define two helper functions inside our dot Emacs configuration. The
 ;;;;;;;;;;;;;;;
 
 (defun vg-get-the-project-path()
-  "Get's a projects root directory if found.
-Tries to find the .git folder or a .dirlocals.el file and basis the projects
+  "Get a projects root directory if found.
+Try to find the .git folder or a .dirlocals.el file and base the projects
 root on that."
   (let ((dirlocals-file (locate-dominating-file default-directory ".dir-locals.el"))
         (git-folder (locate-dominating-file default-directory ".git")))


### PR DESCRIPTION
All the functions in this snippet are documented using the imperative verb form. I guess this is the standard.

The `vg-get-the-project-path` function not consistently uses present. It also contains a little typo ("Get's" instead of "Get").

This PR fixed the grammar typo and aligns the `vg-get-the-project-path` documentation to the other ones'.